### PR TITLE
Use proper branch name

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,7 +9,7 @@ jobs:
     name: pre release
 
     steps:
-      - uses: radcortez/project-metadata-action@master
+      - uses: radcortez/project-metadata-action@main
         name: retrieve project metadata
         id: metadata
         with:


### PR DESCRIPTION
The master branch has been renamed to main, which prevents the pre-release from working as expected. See https://github.com/quarkiverse/quarkus-groovy/actions/runs/13115138493/job/36587623169?pr=214 for more details