### PR TITLE
Remove wait and log display steps from release workflow

### DIFF
--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -163,9 +163,15 @@ jobs:
 
       - name: Report Job Summary
         run: |
-          echo "## Deployment status" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployment status" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
           echo "Monitor the artifacts being deployed to central here:" >> $GITHUB_STEP_SUMMARY
           echo "- [${RELEASE_WORKFLOW_RUN_NAME}](${SUMMARY_URL})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
+          echo "Or use the `gh` tool locally:" >> $GITHUB_STEP_SUMMARY
+          echo "- `gh run watch ${RELEASE_WORKFLOW_ID} -R quarkiverse/quarkiverse-release`" >> $GITHUB_STEP_SUMMARY
+          echo "To display the logs if the release failed:" >> $GITHUB_STEP_SUMMARY
+          echo "- `gh run view ${RELEASE_WORKFLOW_ID} -R quarkiverse/quarkiverse-release --log-failed`" >> $GITHUB_STEP_SUMMARY
         env:
           SUMMARY_URL: ${{ steps.out.outputs.release-workflow-url }}
+          RELEASE_WORKFLOW_ID: ${{ steps.out.outputs.release-workflow-id }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -169,18 +169,3 @@ jobs:
           echo "- [${RELEASE_WORKFLOW_RUN_NAME}](${SUMMARY_URL})" >> $GITHUB_STEP_SUMMARY
         env:
           SUMMARY_URL: ${{ steps.out.outputs.release-workflow-url }}
-
-      - name: Wait for the release workflow to finish
-        run: |
-          gh run watch ${RELEASE_WORKFLOW_ID} -R quarkiverse/quarkiverse-release --exit-status
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_WORKFLOW_ID: ${{ steps.out.outputs.release-workflow-id }}
-
-      - name: Display release logs if failed
-        if: failure()
-        run: |
-          gh run view ${RELEASE_WORKFLOW_ID} -R quarkiverse/quarkiverse-release --log-failed
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_WORKFLOW_ID: ${{ steps.out.outputs.release-workflow-id }}


### PR DESCRIPTION
Removing because it doesn't add any value and it frees the runner instance for other activities. 

The `Report Job Summary` already adds an annotation to the workflow summary with a link if you want to check what's going on with the build.

<img width="1370" height="764" alt="image" src="https://github.com/user-attachments/assets/a365ab6c-9e87-4d8f-8108-e1fdbb330170" />
