### PR TITLE
Introduce alternative input

### DIFF
--- a/.github/workflows/quarkus-ecosystem-ci.yml
+++ b/.github/workflows/quarkus-ecosystem-ci.yml
@@ -29,7 +29,10 @@ on:
         required: false
         description: "Name of the property in the POM file that defines the Quarkus version. By default, it's set to 'quarkus.platform.version'."
         type: string
-
+      alternative:
+        required: false
+        description: "Name of the alternative Quarkus version to use, e.g. '3.15', '3.33'."
+        type: string
   # For this CI to work, ECOSYSTEM_CI_TOKEN needs to contain a GitHub with rights to close the Quarkus issue that the user/bot has opened,
   # while 'ECOSYSTEM_CI_REPO_PATH' needs to be set to the corresponding path in the 'quarkusio/quarkus-ecosystem-ci' repository
 
@@ -45,7 +48,7 @@ env:
   ECOSYSTEM_CI_REPO_PATH: ${{ inputs.ecosystem_ci_repo_path}}
   QUARKUS_VERSION_POM_PATH: ${{ inputs.quarkus_version_pom_path }}
   QUARKUS_VERSION_POM_PROPERTY: ${{ inputs.quarkus_version_pom_property }}
-
+  ALTERNATIVE: ${{ inputs.alternative }}
 permissions:
   contents: read
 
@@ -98,6 +101,7 @@ jobs:
           QUARKUS_VERSION_POM_PATH: ${{ env.QUARKUS_VERSION_POM_PATH }}
           QUARKUS_VERSION_POM_PROPERTY: ${{ env.QUARKUS_VERSION_POM_PROPERTY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALTERNATIVE: ${{ env.ALTERNATIVE }}
 
       - name: Invoke Post Ecosystem Hook (if exists)
         if: ${{ hashFiles('./current-repo/.github/workflows/hooks/post-quarkus-ecosystem-ci.sh') != '' }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/quarkus-ecosystem-ci.yml` workflow to introduce support for specifying an alternative Quarkus version.

It aims to configure the https://github.com/quarkusio/quarkus-ecosystem-ci/blob/main/setup-and-test script.