### PR TITLE
Fix pre ecosystem hook

### DIFF
--- a/.github/workflows/quarkus-ecosystem-ci.yml
+++ b/.github/workflows/quarkus-ecosystem-ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Invoke Pre Ecosystem Hook (if exists)
         if: ${{ hashFiles('./ecosystem-ci/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh') != '' }}
-        run: ./current-repo/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh
+        run: ./ecosystem-ci/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/quarkus-ecosystem-ci.yml
+++ b/.github/workflows/quarkus-ecosystem-ci.yml
@@ -100,7 +100,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Invoke Post Ecosystem Hook (if exists)
-        if: ${{ hashFiles('./current-repo/.github/workflows/hooks/post-quarkus-ecosystem-ci.sh') != '' }}
-        run: ./current-repo/.github/workflows/hooks/post-quarkus-ecosystem-ci.sh
+        if: ${{ hashFiles('./ecosystem-ci/.github/workflows/hooks/post-quarkus-ecosystem-ci.sh') != '' }}
+        run: ./ecosystem-ci/.github/workflows/hooks/post-quarkus-ecosystem-ci.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quarkus-ecosystem-ci.yml
+++ b/.github/workflows/quarkus-ecosystem-ci.yml
@@ -86,7 +86,7 @@ jobs:
             ${{ runner.os }}-maven-wrapper-
 
       - name: Invoke Pre Ecosystem Hook (if exists)
-        if: ${{ hashFiles('./current-repo/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh') != '' }}
+        if: ${{ hashFiles('./ecosystem-ci/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh') != '' }}
         run: ./current-repo/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the workflow logic in `.github/workflows/quarkus-ecosystem-ci.yml` to check for the existence of a pre-ecosystem hook script in a new location before attempting to run it.

Workflow logic update:

* The condition for invoking the pre-ecosystem hook now checks for the script in `./ecosystem-ci/.github/workflows/hooks/` instead of `./current-repo/.github/workflows/hooks/`, ensuring the workflow only runs the hook if the script exists in the intended directory.

NOTE: Currently the workflow is looking to a hook file in the current repo (we do not have it here), it should look the target repo instead.