### PR TITLE
Declare ECOSYSTEM_CI_TOKEN secret in reusable workflow

### DIFF
--- a/.github/workflows/quarkus-ecosystem-ci.yml
+++ b/.github/workflows/quarkus-ecosystem-ci.yml
@@ -33,6 +33,10 @@ on:
         required: false
         description: "Name of the alternative Quarkus version to use, e.g. '3.15', '3.33'."
         type: string
+    secrets:
+      ECOSYSTEM_CI_TOKEN:
+        description: "A GitHub token with rights to close the Quarkus issue that the user/bot has opened"
+        required: true
   # For this CI to work, ECOSYSTEM_CI_TOKEN needs to contain a GitHub with rights to close the Quarkus issue that the user/bot has opened,
   # while 'ECOSYSTEM_CI_REPO_PATH' needs to be set to the corresponding path in the 'quarkusio/quarkus-ecosystem-ci' repository
 


### PR DESCRIPTION
## Summary
- Add explicit `secrets` declaration for `ECOSYSTEM_CI_TOKEN` to the `workflow_call` trigger in the reusable ecosystem CI workflow
- Without this, callers from other organizations cannot pass `ECOSYSTEM_CI_TOKEN` when using `secrets: inherit`, causing "Bad credentials" failures in the ecosystem CI reporting tool

## Context
- Same fix as https://github.com/quarkusio/.github/pull/15